### PR TITLE
In the event you're interested.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,17 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# =========================
+# Atom files
+# =========================
+Thumbs.db
+.nvm-version
+node_modules
+npm-debug.log
+debug.log
+/tags
+/atom-shell/
+docs/output
+docs/includes
+spec/fixtures/evil-files/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Juan M Garcia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# packages package
+## Credit where credit is due
 
-HL7 Support for Atom.  Adapted from Sublime Text package. 
+See [probers1/language-hl7](https://github.com/probers1/language-hl7)
+
+## packages package
+
+HL7 Support for Atom.  Adapted from Sublime Text package.
+
+## But I helped too!
+
+Much of this already existed however it wasn't in the Atom registry and me and
+my team wanted some additional pieces such as easy to spot missing line breaks
+after a PID segment, an easy to spot Patient Identifier, etc.
+
+It also wasn't in the Atom Registry so one would have to clone to desktop and
+move it over to ~/.atom/packages
+
+If there is something missing that YOU want to see feel free to let me know
+I'll work on it when I can - you're also free to add it yourself!

--- a/grammars/hl7.cson
+++ b/grammars/hl7.cson
@@ -7,25 +7,31 @@ patterns: [
   {
     ###
     Very clearly identify HL7 segments so we can tell when them apart in the event
-    that they are get nested for some reason
+    that they are get nested for some reason (it happens)
     ###
     comment: "SegmentOptions"
     match: "(DG1|EVN|GT1|IN1|MSH|NK1|NTE|OBR|OBX|ORC|PID|PV1|PV2|FT1)"
-    name: "keyword.control.hl7.segments"
+    name: "entity.name.type"
   }
   {
-    match: "^(.*?)(\\|)"
-    captures:
-      "1":
-        name: "keyword.operator.hl7"
-      "2":
-        name: "constant.character.hl7"
+    ###
+    Identify HL7 characters that have been escaped.
+    ###
+    comment: "EscapeSequences"
+    match: "(\\\\.+\\\\)"
+    name: "constant.numeric"
   }
   {
+    ###
+    Identify all HL7 special characters
+    ###
     match: "(\\^|~|\\\\|&)"
     name: "string.other.hl7"
   }
   {
+    ###
+    Grabs the type of message and the associated trigger type
+    ###
     begin: "(\\|)(ADT|MDM|MFN|PPR|OMG|ORU|ORM|REF|ACK|DFT)...."
     beginCaptures:
       "1":
@@ -44,11 +50,17 @@ patterns: [
     ]
   }
   {
+    ###
+    HL7 follows YYYYMMDDHHMMSSsss
+    ###
     comment: "DateTime"
     match: "(((19|20)\\d\\d)(0?[1-9]|1[012])(0?[1-9]|[12][0-9]|3[01])([01]?[0-9]|2[0-3])?([0-5][0-9])?([0-5][0-9])?([0-5][0-9])?([0-9][0-9][0-9][0-9][0-9][0-9]?[0-9]?)?)"
     name: "entity.other.inherited-class.hl7"
   }
   {
+    ###
+    Social for those of us in the states
+    ###
     comment: "SSN"
     begin: "(\\|){1}(\\d{3}(-?)\\d{2}(-?)\\d{4})(\\^|\\|){1}"
     beginCaptures:
@@ -68,11 +80,17 @@ patterns: [
     ]
   }
   {
+    ###
+    Attempt to identify phone numbers country codes accounted for somewhat
+    ###
     comment: "PhoneNum"
-    match: "((\\(?)\\d{3}(\\)?)[-|\\^]?\\d{3}[-]?\\d{4})"
+    match: "(\\d{3}?(\\(?)\\d{3}(\\)?)[-|\\^]?\\d{3}[-]?\\d{4})"
     name: "support.function.hl7"
   }
   {
+    ###
+    Identify all separators
+    ###
     match: "\\|"
     name: "constant.character.hl7"
   }

--- a/grammars/hl7.cson
+++ b/grammars/hl7.cson
@@ -11,7 +11,7 @@ patterns: [
     ###
     comment: "SegmentOptions"
     match: "(DG1|EVN|GT1|IN1|MSH|NK1|NTE|OBR|OBX|ORC|PID|PV1|PV2|FT1)"
-    name: "entity.name.type"
+    name: "entity.name.type.hl7.segment"
   }
   {
     ###

--- a/grammars/hl7.cson
+++ b/grammars/hl7.cson
@@ -5,6 +5,15 @@ fileTypes: [
 name: "HL7"
 patterns: [
   {
+    ###
+    Very clearly identify HL7 segments so we can tell when them apart in the event
+    that they are get nested for some reason
+    ###
+    comment: "SegmentOptions"
+    match: "(DG1|EVN|GT1|IN1|MSH|NK1|NTE|OBR|OBX|ORC|PID|PV1|PV2|FT1)"
+    name: "keyword.control.hl7.segments"
+  }
+  {
     match: "^(.*?)(\\|)"
     captures:
       "1":
@@ -36,7 +45,7 @@ patterns: [
   }
   {
     comment: "DateTime"
-    match: "(((19|20)\\d\\d)(0?[1-9]|1[012])(0?[1-9]|[12][0-9]|3[01])([01]?[0-9]|2[0-3])?([0-5][0-9])?([0-5][0-9])?([0-5][0-9])?([0-9][0-9][0-9][0-9])?)"
+    match: "(((19|20)\\d\\d)(0?[1-9]|1[012])(0?[1-9]|[12][0-9]|3[01])([01]?[0-9]|2[0-3])?([0-5][0-9])?([0-5][0-9])?([0-5][0-9])?([0-9][0-9][0-9][0-9][0-9][0-9]?[0-9]?)?)"
     name: "entity.other.inherited-class.hl7"
   }
   {
@@ -66,6 +75,14 @@ patterns: [
   {
     match: "\\|"
     name: "constant.character.hl7"
+  }
+  {
+    ###
+    Attempts to capture all instaces of where a patient id was found
+    ###
+    comment: "PatientIdentifier"
+    match: "((\\d+(\\^\\^\\^)(.[^\\\|^]+))+)"
+    name: "support.function.hl7"
   }
 ]
 scopeName: "text.hl7"

--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
   "name": "language-hl7",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "HL7 Support for Atom",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/kelvix/language-hl7"
+    "type": "git",
+    "url": "https://github.com/kelvix/language-hl7"
   },
-  "bugs" : {
-    "url" : ""
+  "bugs": {
+    "url": ""
   },
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "language-hl7",
   "version": "0.0.0",
   "description": "HL7 Support for Atom",
-  "repository": "https://github.com/atom/packages",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/kelvix/language-hl7"
+  },
+  "bugs" : {
+    "url" : ""
+  },
   "license": "MIT",
   "engines": {
-    "atom": ">=0.174.0 <2.0.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
   }

--- a/spec/hl7-spec.coffee
+++ b/spec/hl7-spec.coffee
@@ -21,4 +21,11 @@ describe "HL7 grammar", ->
       NK1||ROE^MARIE^^^^|SPO||(216)123-4567||EC|||||||||||||||||||||||||||
     """
 
-    expect(lines[1]).toEqual value: "NK1", scopes: ["text.hl7", "entity.name.type"]
+    expect(lines[0][0]).toEqual value: "NK1", scopes: ["text.hl7", "entity.name.type.hl7.segment"]
+
+  it "determines the social security number", ->
+    lines = grammar.tokenizeLines """
+      PID||0493575^^^2^ID 1|454721||DOE^JOHN^^^^|DOE^JOHN^^^^|19480203|M||B|254 MYSTREET AVE^^MYTOWN^OH^44123^USA||(216)123-4567|||M|NON|400003403~1129086|333-33-3333|
+    """
+
+    expect(lines[0][61]).toEqual value: "333-33-3333", scopes: ["text.hl7", "constant.character.hl7", "entity.other.inherited-class.hl7"]

--- a/spec/hl7-spec.coffee
+++ b/spec/hl7-spec.coffee
@@ -1,0 +1,24 @@
+{TextEditor} = require "atom"
+fs = require "fs"
+path = require "path"
+
+describe "HL7 grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-hl7")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("text.hl7")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe "text.hl7"
+
+  it "determines the segment type", ->
+    lines = grammar.tokenizeLines """
+      NK1||ROE^MARIE^^^^|SPO||(216)123-4567||EC|||||||||||||||||||||||||||
+    """
+
+    expect(lines[1]).toEqual value: "NK1", scopes: ["text.hl7", "entity.name.type"]


### PR DESCRIPTION
I added a MIT license basically the most permissive license ever. If you're not fine with this you may want to reject the pull. It's also now available from the package manager from within atom.

Extras include easily identifiable segments i.e MSH, PID, PV1, etc no matter where they are, special character escapes i.e \T\, patient id i.e pid 2.2 or pid 2.3 3123^^^OID&ISO, and now that i think about it patient id can be alphanumeric and contains periods which I'm not accounting for atm.

I can't create a issues page since you own the repo.
